### PR TITLE
♻️ Refactor Auth0 callback function to provide user profile data

### DIFF
--- a/src/Auth.js
+++ b/src/Auth.js
@@ -29,7 +29,7 @@ export default class Auth {
       this.auth0.parseHash((err, authResult) => {
         if (authResult && authResult.accessToken && authResult.idToken) {
           this.setSession(authResult);
-          callback(authResult.accessToken);
+          callback(authResult.accessToken, authResult.idToken);
           props.history.push('/');
         } else if (err) {
           console.log(err);

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -64,7 +64,7 @@ export function loginUser(id_token) {
   };
 }
 
-export function auth0Login(id_token) {
+export function auth0Login(access_token, id_token) {
   return dispatch => {
     dispatch(beginAuth(true));
     const jwtData = jwtDecode(id_token);
@@ -78,6 +78,6 @@ export function auth0Login(id_token) {
       roles: jwtData['https://kidsfirstdrc.org/roles'],
       permissions: jwtData['https://kidsfirstdrc.org/permissions']
     };
-    dispatch(authSuccess(id_token, jwtData.exp, user));
+    dispatch(authSuccess(access_token, jwtData.exp, user));
   };
 }

--- a/src/views/Callback.js
+++ b/src/views/Callback.js
@@ -14,7 +14,8 @@ class Callback extends Component {
 
 function mapDispatchToProps(dispatch) {
   return {
-    auth0Login: id_token => dispatch(auth0Login(id_token))
+    auth0Login: (access_token, id_token) =>
+      dispatch(auth0Login(access_token, id_token))
   };
 }
 


### PR DESCRIPTION
Pass both `accessToken` and `idToken` to the Auth0 login callback function, so that we can access to user profile data for `/profile` screen.