### PR TITLE
🔧 Add netlify.toml configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
Configuration needed to redirect callback urls to `/index.html` for the SPA.