### PR TITLE
🐛 Don't show cards if there are no releases

### DIFF
--- a/src/containers/StudiesContainer.js
+++ b/src/containers/StudiesContainer.js
@@ -39,7 +39,7 @@ class StudiesContainer extends Component {
         <Button
           onClick={() => this.props.syncStudies()}
           disabled={this.props.syncing}
-          color="primary"
+          primary
           icon
           labelPosition="left"
         >

--- a/src/forms/NewReleaseForm.js
+++ b/src/forms/NewReleaseForm.js
@@ -178,7 +178,8 @@ const NewReleaseForm = props => {
             {release.studies && (
               <Label.Group>
                 {release.studies.map(sd => (
-                  <Label color="pink" icon="database">
+                  <Label basic key={sd}>
+                    <Icon name="database" />
                     {sd}
                   </Label>
                 ))}

--- a/src/views/Release.js
+++ b/src/views/Release.js
@@ -215,7 +215,7 @@ class Release extends Component {
           />
         );
       }
-      return <Fragment />;
+      return <Fragment key={i} />;
     });
 
     return (
@@ -269,8 +269,8 @@ class Release extends Component {
                 <Grid.Row centered>
                   <Label.Group>
                     {this.state.release.studies.map((r, i) => (
-                      <Label basic>
-                        <Icon name="database" key={i} />
+                      <Label key={i} basic>
+                        <Icon name="database" />
                         {r}
                       </Label>
                     ))}
@@ -400,7 +400,8 @@ class Release extends Component {
               {this.state.release.studies && (
                 <Label.Group>
                   {this.state.release.studies.map(sd => (
-                    <Label basic icon="database">
+                    <Label basic key={sd}>
+                      <Icon name="database" />
                       {sd}
                     </Label>
                   ))}
@@ -434,7 +435,7 @@ class StudyNotes extends Component {
       );
     }
     const notes = this.props.notes.map((note, i) => (
-      <article>
+      <article key={i}>
         <em>
           Note by {note.author} <TimeAgo date={note.created_at} />
         </em>

--- a/src/views/Status.js
+++ b/src/views/Status.js
@@ -49,13 +49,15 @@ class Status extends Component {
         <Card fluid>
           <Card.Content>
             <Card.Header>Latest Publication</Card.Header>
-            <LatestPublish />
+            {this.state.latest.length > 1 && <LatestPublish />}
           </Card.Content>
         </Card>
         <Card fluid>
           <Card.Content>
             <Card.Header>Latest Releases</Card.Header>
-            <LatestReleases releases={this.state.latest.reverse()} />
+            {this.state.latest.length > 1 && (
+              <LatestReleases releases={this.state.latest.reverse()} />
+            )}
           </Card.Content>
         </Card>
 


### PR DESCRIPTION
If there are no releases in existence, the status page will fail to render due to the cards expecting at least one release.
This adds a conditional render that will not render the card contents if there are no releases.