### PR TITLE
🐛 Fix mm/dd/yyyy format date utility function

### DIFF
--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -57,7 +57,7 @@ export const longDate = date => {
 
 export const numDate = date => {
   var mydate = new Date(date);
-  var str =
-    mydate.getMonth() + '/' + mydate.getUTCDate() + '/' + mydate.getFullYear();
+  const month = mydate.getMonth() + 1;
+  var str = month + '/' + mydate.getUTCDate() + '/' + mydate.getFullYear();
   return str;
 };


### PR DESCRIPTION
`mm/dd/yyyy` format date was one month behind the date input. 